### PR TITLE
Refactor kotlin version

### DIFF
--- a/src/main/kotlin/com/dynatrace/kachedproperties/TimeBoundCache.kt
+++ b/src/main/kotlin/com/dynatrace/kachedproperties/TimeBoundCache.kt
@@ -1,0 +1,59 @@
+package com.dynatrace.kachedproperties
+
+import java.time.Duration
+import java.util.concurrent.Executor
+
+class TimeBoundCache<T: Any>(
+    private val updateDuration: Duration,
+    private val provideValue: () -> T,
+    private val lazyRefresh: Boolean,
+    private val executor: Executor?,
+    private val timeSource: TimeSource,
+) {
+    init {
+        timeSource.markNow()
+    }
+
+    private var notFirstInit = false
+    private var beingUpdated = false
+    private lateinit var lastValue: T
+
+    fun getValue(): T {
+        synchronized(notFirstInit) {
+            if (!notFirstInit) {
+                updateValue()
+                notFirstInit = true
+            }
+
+            if (timeSource.elapsedTime() >= updateDuration) {
+                return queueUpdateValue()
+            }
+        }
+        return lastValue
+    }
+
+    private fun queueUpdateValue(): T {
+        val last = lastValue
+        if (beingUpdated) {
+            return last
+        }
+
+        beingUpdated = true
+        if (!lazyRefresh || executor == null) {
+            updateValue()
+            beingUpdated = false
+            return lastValue
+        }
+
+        executor.execute {
+            updateValue()
+            beingUpdated = false
+        }
+        return last
+    }
+
+    private fun updateValue() {
+        lastValue = provideValue()
+        timeSource.markNow()
+    }
+}

--- a/src/main/kotlin/com/dynatrace/kachedproperties/TimeBoundCacheDelegatedProperty.kt
+++ b/src/main/kotlin/com/dynatrace/kachedproperties/TimeBoundCacheDelegatedProperty.kt
@@ -1,78 +1,25 @@
 package com.dynatrace.kachedproperties
 
+import java.time.Duration
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import kotlin.reflect.KProperty
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
-import kotlin.time.TimeSource
 
-@ExperimentalTime
-fun <T : Any> cachedWithLazyRefreshFor(
+fun <T : Any> cachedLazyFor(
     updateDuration: Duration,
     provideValue: () -> T,
     executor: Executor = Executors.newCachedThreadPool(),
-    timeSource: TimeSource = TimeSource.Monotonic
+    timeSource: TimeSource = SystemTimeSource()
 ) =
-    TimeBoundCacheDelegatedProperty(updateDuration, provideValue, true, executor, timeSource)
+    TimeBoundCacheDelegatedProperty(TimeBoundCache(updateDuration, provideValue, true, executor, timeSource))
 
-@ExperimentalTime
-fun <T : Any> cachedFor(
+fun <T : Any> cachedBlockingFor(
     updateDuration: Duration,
     provideValue: () -> T,
-    timeSource: TimeSource = TimeSource.Monotonic
+    timeSource: TimeSource = SystemTimeSource()
 ) =
-    TimeBoundCacheDelegatedProperty(updateDuration, provideValue, false, null, timeSource)
+    TimeBoundCacheDelegatedProperty(TimeBoundCache(updateDuration, provideValue, false, null, timeSource))
 
-@ExperimentalTime
-class TimeBoundCacheDelegatedProperty<T : Any>(
-    private val updateDuration: Duration,
-    private val provideValue: () -> T,
-    private val lazyRefresh: Boolean,
-    private val executor: Executor?,
-    private val timeSource: TimeSource,
-) {
-    private var lastFetchedTimeMark = timeSource.markNow()
-    private var notFirstInit = false
-    private var beingUpdated = false
-    private lateinit var lastValue: T
-
-    operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
-        synchronized(notFirstInit) {
-            if (!notFirstInit) {
-                updateValue()
-                notFirstInit = true
-            }
-
-            if (lastFetchedTimeMark.elapsedNow() >= updateDuration) {
-                return queueUpdateValue()
-            }
-        }
-        return lastValue
-    }
-
-    private fun queueUpdateValue(): T {
-        val last = lastValue
-        if (beingUpdated) {
-            return last
-        }
-
-        beingUpdated = true
-        if (!lazyRefresh || executor == null) {
-            updateValue()
-            beingUpdated = false
-            return lastValue
-        }
-
-        executor.execute {
-            updateValue()
-            beingUpdated = false
-        }
-        return last
-    }
-
-    private fun updateValue() {
-        lastValue = provideValue()
-        lastFetchedTimeMark = timeSource.markNow()
-    }
+class TimeBoundCacheDelegatedProperty<T: Any>(val cache: TimeBoundCache<T>) {
+    operator fun getValue(thisRef: Any?, property: KProperty<*>) = cache.getValue()
 }

--- a/src/main/kotlin/com/dynatrace/kachedproperties/TimeSource.kt
+++ b/src/main/kotlin/com/dynatrace/kachedproperties/TimeSource.kt
@@ -1,0 +1,49 @@
+package com.dynatrace.kachedproperties
+
+import java.time.Duration
+import java.time.Instant
+
+interface TimeSource {
+    fun markNow(): Instant
+    fun elapsedTime(): Duration
+}
+
+class SystemTimeSource: TimeSource {
+    private var time: Instant = Instant.now()
+
+    override fun markNow(): Instant {
+        time = Instant.now()
+        return time
+    }
+
+    override fun elapsedTime(): Duration {
+        val currentTime = Instant.now()
+        return Duration.between(time, currentTime)
+    }
+}
+
+class SimulatedTimeSource: TimeSource {
+    private var time: Instant = Instant.now()
+    private var currentTime: Instant = Instant.now()
+
+    override fun markNow(): Instant {
+        time = currentTime
+        return time
+    }
+
+    fun setTime(instant: Instant) {
+        time = instant
+    }
+
+    fun setCurrentTime(instant: Instant) {
+        currentTime = instant
+    }
+
+    fun advanceBy(duration: Duration) {
+        currentTime = currentTime.plus(duration)
+    }
+
+    override fun elapsedTime(): Duration {
+        return Duration.between(time, currentTime)
+    }
+}

--- a/src/test/kotlin/com/dynatrace/kachedproperties/TimeBoundCacheDelegatedPropertyTest.kt
+++ b/src/test/kotlin/com/dynatrace/kachedproperties/TimeBoundCacheDelegatedPropertyTest.kt
@@ -6,25 +6,22 @@ import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.lang.Thread.sleep
+import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
-import kotlin.time.ExperimentalTime
-import kotlin.time.TestTimeSource
-import kotlin.time.seconds
 
-@ExperimentalTime
 class TimeBoundCacheDelegatedPropertyTest {
     @Test
     fun `should return the same value when cache didn't expire`() {
-        val mockTimeSource = TestTimeSource()
+        val mockTimeSource = SimulatedTimeSource()
         val fetchValueFromDependency = mockk<() -> String>()
         every { fetchValueFromDependency() } returnsMany listOf("Call 1", "Call 2")
-        val cachedValue by cachedWithLazyRefreshFor(5.seconds, { fetchValueFromDependency() }, timeSource = mockTimeSource)
+        val cachedValue by cachedLazyFor(Duration.ofSeconds(5), { fetchValueFromDependency() }, timeSource = mockTimeSource)
 
         assertEquals("Call 1", cachedValue)
-        mockTimeSource += 2.seconds
+        mockTimeSource.advanceBy(Duration.ofSeconds(2))
         assertEquals("Call 1", cachedValue)
 
         verify(exactly = 1) { fetchValueFromDependency() }
@@ -32,13 +29,13 @@ class TimeBoundCacheDelegatedPropertyTest {
 
     @Test
     fun `should update the value after the cache expires`() {
-        val mockTimeSource = TestTimeSource()
+        val mockTimeSource = SimulatedTimeSource()
         val fetchValueFromDependency = mockk<() -> String>()
         every { fetchValueFromDependency() } returnsMany listOf("Call 1", "Call 2")
-        val cachedValue by cachedFor(5.seconds, { fetchValueFromDependency() }, mockTimeSource)
+        val cachedValue by cachedBlockingFor(Duration.ofSeconds(5), { fetchValueFromDependency() }, mockTimeSource)
 
         assertEquals("Call 1", cachedValue)
-        mockTimeSource += 10.seconds
+        mockTimeSource.advanceBy(Duration.ofSeconds(10))
         assertEquals("Call 2", cachedValue)
 
         verify(exactly = 2) { fetchValueFromDependency() }
@@ -46,14 +43,14 @@ class TimeBoundCacheDelegatedPropertyTest {
 
     @Test
     fun `should return same value when different threads call it for updating with lazy refresh `() {
-        val mockTimeSource = TestTimeSource()
+        val mockTimeSource = SimulatedTimeSource()
         val fetchValueFromDependency = mockk<() -> String>()
         val dependencyCallCounter = AtomicInteger(1)
         every { fetchValueFromDependency() } answers {
-            sleep(1.seconds.toLongMilliseconds()) // Simulating long network call.
+            sleep(1000) // Simulating long network call.
             "Call ${dependencyCallCounter.getAndIncrement()}"
         }
-        val cachedValue by cachedWithLazyRefreshFor(5.seconds, { fetchValueFromDependency() }, timeSource = mockTimeSource)
+        val cachedValue by cachedLazyFor(Duration.ofSeconds(5), { fetchValueFromDependency() }, timeSource = mockTimeSource)
 
         lateinit var cachedValueReadFromThread1: String
         lateinit var cachedValueReadFromThread2: String
@@ -74,14 +71,14 @@ class TimeBoundCacheDelegatedPropertyTest {
 
     @Test
     fun `should return same value when different threads call it for updating without lazy refresh`() {
-        val mockTimeSource = TestTimeSource()
+        val mockTimeSource = SimulatedTimeSource()
         val fetchValueFromDependency = mockk<() -> String>()
         val dependencyCallCounter = AtomicInteger(1)
         every { fetchValueFromDependency() } answers {
-            sleep(1.seconds.toLongMilliseconds()) // Simulating long network call.
+            sleep(1000) // Simulating long network call.
             "Call ${dependencyCallCounter.getAndIncrement()}"
         }
-        val cachedValue by cachedFor(5.seconds, { fetchValueFromDependency() }, mockTimeSource)
+        val cachedValue by cachedBlockingFor(Duration.ofSeconds(5), { fetchValueFromDependency() }, mockTimeSource)
 
         lateinit var cachedValueReadFromThread1: String
         lateinit var cachedValueReadFromThread2: String
@@ -102,18 +99,18 @@ class TimeBoundCacheDelegatedPropertyTest {
 
     @Test
     fun `should return same value with lazy refresh`() {
-        val mockTimeSource = TestTimeSource()
+        val mockTimeSource = SimulatedTimeSource()
         val executor = Executors.newSingleThreadExecutor()
         val fetchValueFromDependency = mockk<() -> String>()
         val dependencyCallCounter = AtomicInteger(1)
         every { fetchValueFromDependency() } answers {
-            sleep(1.seconds.toLongMilliseconds()) // Simulating long network call.
+            sleep(1000) // Simulating long network call.
             "Call ${dependencyCallCounter.getAndIncrement()}"
         }
-        val cachedValue by cachedWithLazyRefreshFor(5.seconds, { fetchValueFromDependency() }, executor, mockTimeSource)
+        val cachedValue by cachedLazyFor(Duration.ofSeconds(5), { fetchValueFromDependency() }, executor, mockTimeSource)
 
         val cachedValueReadFromThread1: String = cachedValue
-        mockTimeSource += 10.seconds
+        mockTimeSource.advanceBy(Duration.ofSeconds(10))
         val cachedValueReadFromThread2: String = cachedValue
 
         val retrievedValues = setOf(cachedValueReadFromThread1, cachedValueReadFromThread2)
@@ -125,17 +122,17 @@ class TimeBoundCacheDelegatedPropertyTest {
 
     @Test
     fun `should return updated value immediately without lazy refresh`() {
-        val mockTimeSource = TestTimeSource()
+        val mockTimeSource = SimulatedTimeSource()
         val fetchValueFromDependency = mockk<() -> String>()
         val dependencyCallCounter = AtomicInteger(1)
         every { fetchValueFromDependency() } answers {
-            sleep(1.seconds.toLongMilliseconds()) // Simulating long network call.
+            sleep(1000) // Simulating long network call.
             "Call ${dependencyCallCounter.getAndIncrement()}"
         }
-        val cachedValue by cachedFor(5.seconds, { fetchValueFromDependency() }, mockTimeSource)
+        val cachedValue by cachedBlockingFor(Duration.ofSeconds(5), { fetchValueFromDependency() }, mockTimeSource)
 
         val read1: String = cachedValue
-        mockTimeSource += 10.seconds
+        mockTimeSource.advanceBy(Duration.ofSeconds(10))
         val read2: String = cachedValue
 
         val retrievedValues = setOf(read1, read2)


### PR DESCRIPTION
Problem
=====

- We always update values in the background
- There is no way to setup a custom thread pool for updating values in the background
- Code is a bit difficult to follow


Goal
=====

- Add a way to update in a sync way
- Receive a executor for running on specific thread pools
- Rearrange code a bit


Implementation
=====

- Adds a new version of the function that receive a optional executor and updates in the background
- Old function now does the update immediately
- Rearrange the code a bit


Caveats
=====

None.


Further considerations
=====

None.


ToDo list
=====

None.
