### PR TITLE
[#23] Fix fetching values after 'provideValue' recovers from exceptions

### DIFF
--- a/src/main/kotlin/com/dynatrace/kachedproperties/TimeBoundCache.kt
+++ b/src/main/kotlin/com/dynatrace/kachedproperties/TimeBoundCache.kt
@@ -54,11 +54,7 @@ class TimeBoundCache<T : Any>(
 
         beingUpdated = true
         if (!lazyRefresh || executor == null) {
-            try {
-                updateValue()
-            } finally {
-                beingUpdated = false
-            }
+            updateValue()
             return lastValue
         }
 

--- a/src/main/kotlin/com/dynatrace/kachedproperties/TimeBoundCache.kt
+++ b/src/main/kotlin/com/dynatrace/kachedproperties/TimeBoundCache.kt
@@ -54,20 +54,26 @@ class TimeBoundCache<T : Any>(
 
         beingUpdated = true
         if (!lazyRefresh || executor == null) {
-            updateValue()
-            beingUpdated = false
+            try {
+                updateValue()
+            } finally {
+                beingUpdated = false
+            }
             return lastValue
         }
 
         executor.execute {
             updateValue()
-            beingUpdated = false
         }
         return last
     }
 
     private fun updateValue() {
-        lastValue = provideValue()
-        timeSource.markNow()
+        try {
+            lastValue = provideValue()
+            timeSource.markNow()
+        } finally {
+            beingUpdated = false
+        }
     }
 }

--- a/src/test/kotlin/com/dynatrace/kachedproperties/TimeBoundCacheDelegatedPropertyTest.kt
+++ b/src/test/kotlin/com/dynatrace/kachedproperties/TimeBoundCacheDelegatedPropertyTest.kt
@@ -168,10 +168,9 @@ class TimeBoundCacheDelegatedPropertyTest {
         verify(exactly = 2) { fetchValueFromDependency() }
     }
 
-    // TODO #23 - this test captures incorrect behavior. Fix will come in a separate commit.
     @Test
     @Suppress("TooGenericExceptionThrown")
-    fun `INCORRECTLY doesn't retry fetching value on next request when fetching value threw an exception - lazy`() {
+    fun `retries fetching value on next request when fetching value threw an exception - lazy version`() {
         val mockTimeSource = SimulatedTimeSource()
         val fetchValueFromDependency = mockk<() -> String>()
         val dependencyCallCounter = AtomicInteger(1)
@@ -200,18 +199,17 @@ class TimeBoundCacheDelegatedPropertyTest {
         assertEquals("Call 1", cachedValue)
         mockTimeSource.advanceBy(Duration.ofSeconds(10))
         sleep(10)
-        assertEquals("Call 1", cachedValue)
+        assertEquals("Call 3", cachedValue)
         mockTimeSource.advanceBy(Duration.ofSeconds(10))
         sleep(10)
-        assertEquals("Call 1", cachedValue)
+        assertEquals("Call 3", cachedValue)
 
-        verify(exactly = 2) { fetchValueFromDependency() }
+        verify(exactly = 4) { fetchValueFromDependency() }
     }
 
-    // TODO #23 - this test captures incorrect behavior. Fix will come in a separate commit.
     @Test
     @Suppress("TooGenericExceptionThrown")
-    fun `INCORRECTLY doesn't retry fetching value on next request when fetching value threw an exception - blocking`() {
+    fun `retries fetching value on next request when fetching value threw an exception - blocking version`() {
         val mockTimeSource = SimulatedTimeSource()
         val fetchValueFromDependency = mockk<() -> String>()
         val dependencyCallCounter = AtomicInteger(1)
@@ -239,14 +237,14 @@ class TimeBoundCacheDelegatedPropertyTest {
         }
         mockTimeSource.advanceBy(Duration.ofSeconds(10))
         sleep(10)
-        assertEquals("Call 1", cachedValue)
+        assertEquals("Call 3", cachedValue)
         mockTimeSource.advanceBy(Duration.ofSeconds(10))
         sleep(10)
-        assertEquals("Call 1", cachedValue)
+        assertEquals("Call 4", cachedValue)
         mockTimeSource.advanceBy(Duration.ofSeconds(10))
         sleep(10)
-        assertEquals("Call 1", cachedValue)
+        assertEquals("Call 5", cachedValue)
 
-        verify(exactly = 2) { fetchValueFromDependency() }
+        verify(exactly = 5) { fetchValueFromDependency() }
     }
 }


### PR DESCRIPTION
See individual commits.

# Testing

Just unit tests - I managed to test it only this way. I had to use some extra `sleep`s here and there, I don't fully understand why.